### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,10 +17,7 @@
   "engines": {
     "node": ">=4"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/matheuss/hpm.git"
-  },
+  "repository": "zeit/hpm",
   "keywords": [
     "hyperterm",
     "package",
@@ -36,9 +33,9 @@
   },
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/matheuss/hpm/issues"
+    "url": "https://github.com/zeit/hpm/issues"
   },
-  "homepage": "https://github.com/matheuss/hpm#readme",
+  "homepage": "https://github.com/zeit/hpm#readme",
   "dependencies": {
     "args": "^2.0.0",
     "chalk": "^1.1.3",


### PR DESCRIPTION
1. **Update all links to zeit/hpm**. matheuss/hpm will currently redirect to zeit/hpm, but GitHub may change its policy and you may (on purpose or not) fork the repository, so the link becomes obsolete.
2. **Use simplified repository property**, per https://docs.npmjs.com/files/package.json#repository.