### PR TITLE
fix(help): fixed name on help and shows help on empty call

### DIFF
--- a/index.js
+++ b/index.js
@@ -156,8 +156,8 @@ args.command(['f', 'fork'], 'Fork a plugin from npm into your ~/.hyper_plugins/l
 	});
 });
 
-const flags = args.parse(process.argv);
+const flags = args.parse(process.argv, {name: 'hpm'});
 
-if (Object.keys(flags).length !== 0) { // Show help when no command is invoked
+if (Object.keys(flags).length === 0) { // Show help when no command is invoked
 	args.showHelp();
 }


### PR DESCRIPTION
Hi!

Fixed hpm showing index.js on the help output.
Also show the help output on empty call: `hpm`.

Thanks