### PR TITLE
Fixes hpm search

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ args.command(['s', 'search'], 'Search for plugins on npm', (name, args) => {
 		.then(entries => {
 			return entries.filter(entry => {
 				return entry.name.indexOf(query) !== -1 ||
-					entry.description.toLowerCase().indexOf(query) !== -1;
+					 (entry.description &&  entry.description.toLowerCase().indexOf(query) !== -1);
 			});
 		})
 		.then(entries => {


### PR DESCRIPTION
Search currently fails because there is one package without a description (hyper-dark-vibrancy)

```$ hpm search vibrancy
✖ Searching
TypeError: Cannot read property 'toLowerCase' of null```