### PR TITLE
Check for a null description in ls-remote of modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ args.command(['s', 'search'], 'Search for plugins on npm', (name, args) => {
 		.then(entries => {
 			return entries.filter(entry => {
 				return entry.name.indexOf(query) !== -1 ||
-					entry.description.toLowerCase().indexOf(query) !== -1;
+					((entry.description) ? entry.description.toLowerCase().indexOf(query) : -1) !== -1;
 			});
 		})
 		.then(entries => {


### PR DESCRIPTION
Fixes #61

A [module](https://www.npmjs.com/package/hyper-dark-vibrancy) recently published has a null description which is causing a typeerror on a search of any parameter.  
