### PR TITLE
Remove support for node 4, 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 node_js:
   - '6'
-  - '5'
-  - '4'
 
 after_success:
   - npm run coverage


### PR DESCRIPTION
Sadly the `args` library used here only supports node 6. 

Currently installing under node 4 or 5 will result in https://github.com/zeit/hpm/issues/57, https://github.com/zeit/hpm/issues/56