### PR TITLE
Fix #72: Change argument checking for show help

### DIFF
--- a/index.js
+++ b/index.js
@@ -156,8 +156,9 @@ args.command(['f', 'fork'], 'Fork a plugin from npm into your ~/.hyper_plugins/l
 	});
 });
 
-const flags = args.parse(process.argv, {name: 'hpm'});
+args.parse(process.argv, {name: 'hpm'});
 
-if (Object.keys(flags).length === 0) { // Show help when no command is invoked
+// Show help when no command is invoked
+if (args.raw._.length === 0 || !args.isDefined(args.raw._[0], 'commands')) {
 	args.showHelp();
 }


### PR DESCRIPTION
I have same problem (#72).

https://github.com/zeit/hpm/blob/master/index.js#L159 is always return `{}`.

I added two validations.
1: `args.raw._.length === 0` for to `hpm` executed with no arguments. Like a `hpm`.
2: `!args.isDefined(args.raw._[0], 'commands')` for to `hpm` executed with not exist command. Like a 'hpm foooo'
