### PR TITLE
Use single quotation marks to match hyper's default config style.

### DIFF
--- a/api.js
+++ b/api.js
@@ -58,7 +58,9 @@ function isInstalled(plugin, locally) {
 }
 
 function save() {
-  return pify(fs.writeFile)(fileName, recast.print(parsedFile).code, 'utf8')
+  return pify(fs.writeFile)(fileName, recast.print(parsedFile, {
+    quote: 'single'
+  }).code, 'utf8')
 }
 
 function existsOnNpm(plugin) {


### PR DESCRIPTION
A little fix to use single quotation marks as String output.

before:
```js
plugins: [
  "hyperpower"
]
```

after:
```js
plugins: [
  'hyperpower'
]
```