### PR TITLE
api: Property key has `.value`, not `.name`

### DIFF
--- a/api.js
+++ b/api.js
@@ -30,11 +30,11 @@ try {
   const expression = parsedFile.program.body[0].expression
   const properties = (expression && expression.right && expression.right.properties) || []
   plugins = properties.find(property => {
-    return property.key.name === 'plugins'
+    return property.key.value === 'plugins'
   }).value.elements
 
   localPlugins = properties.find(property => {
-    return property.key.name === 'localPlugins'
+    return property.key.value === 'localPlugins'
   }).value.elements
 } catch (err) {
   if (err.code !== 'ENOENT') { // ENOENT === !exists()


### PR DESCRIPTION
Fixes #82 

So I'm not super-sure what's up with this. I'd expect this to break on a lot of people if this were the issue but as witnessed by #82 there's only a few people that seem to run into it. After some debugging it seems that the version of recast I got, recast@0.11.23, doesn't have a `.name` attribute on property keys but has a `.value` instead.

```
Property {
    type: 'Property',
    key: 
     Literal {
       type: 'Literal',
       value: 'localPlugins',
       raw: '"localPlugins"',
       loc: [Object] },
```