### PR TITLE
Change AST key parsing to match output of recast (Issues #82/#93)

### DIFF
--- a/api.js
+++ b/api.js
@@ -30,11 +30,11 @@ try {
   const expression = parsedFile.program.body[0].expression
   const properties = (expression && expression.right && expression.right.properties) || []
   plugins = properties.find(property => {
-    return property.key.name === 'plugins'
+    return property.key.value === 'plugins'
   }).value.elements
 
   localPlugins = properties.find(property => {
-    return property.key.name === 'localPlugins'
+    return property.key.value === 'localPlugins'
   }).value.elements
 } catch (err) {
   if (err.code !== 'ENOENT') { // ENOENT === !exists()


### PR DESCRIPTION
Re Issues #82 #93 

Seems to match specs for estree:

https://github.com/estree/estree/blob/master/es5.md#objectexpression
https://github.com/estree/estree/blob/master/es5.md#literal

and works with the output of `recast` that i am getting:

```javascript
[ Property {
    type: 'Property',
    key:
     Literal {
       type: 'Literal',
       value: 'config',
       raw: '"config"',
       loc: [Object] },
    computed: false,
    value: ObjectExpression { type: 'ObjectExpression', properties: [Array], loc: [Object] },
    kind: 'init',
    method: false,
    shorthand: false,
    loc: { start: [Object], end: [Object], lines: Lines {}, indent: 2 } },
  Property {
    type: 'Property',
    key:
     Literal {
       type: 'Literal',
       value: 'modifierKeys',
       raw: '"modifierKeys"',
       loc: [Object] },
    computed: false,
    value: ObjectExpression { type: 'ObjectExpression', properties: [Array], loc: [Object] },
    kind: 'init',
    method: false,
    shorthand: false,
    loc: { start: [Object], end: [Object], lines: Lines {}, indent: 2 } },
  Property {
    type: 'Property',
    key:
     Literal {
       type: 'Literal',
       value: 'plugins',
       raw: '"plugins"',
       loc: [Object] },
    computed: false,
    value: ArrayExpression { type: 'ArrayExpression', elements: [Array], loc: [Object] },
    kind: 'init',
    method: false,
    shorthand: false,
    loc: { start: [Object], end: [Object], lines: Lines {}, indent: 2 } },
  Property {
    type: 'Property',
    key:
     Literal {
       type: 'Literal',
       value: 'localPlugins',
       raw: '"localPlugins"',
       loc: [Object] },
    computed: false,
    value: ArrayExpression { type: 'ArrayExpression', elements: [], loc: [Object] },
    kind: 'init',
    method: false,
    shorthand: false,
    loc: { start: [Object], end: [Object], lines: Lines {}, indent: 2 } } ]
```