### PR TITLE
Add proxy support for hpm

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,17 @@ npm install -g hpm-cli
     -h, --help     Output usage information
     -v, --version  Output the version number
 ```
+
+## Proxy
+`hpm` now supports authenticated proxies. To add proxy settings, create a `.hpmproxy` file in your home directory with the following contents:
+
+```javascript
+var hpmproxy = {
+    proxyHost: 'your.proxy.host.com',
+    proxyPort: 80,
+    proxyAuth: 'username:password',
+    useProxy: true
+}
+module.exports.hpmproxy = hpmproxy
+```
+To disable the proxy, simply set `useProxy` to `false`. 

--- a/package.json
+++ b/package.json
@@ -44,12 +44,13 @@
     "columnify": "^1.5.4",
     "execa": "^0.5.0",
     "file-exists": "^2.0.0",
-    "got": "^6.3.0",
-    "npm-name": "^3.0.0",
+    "got": "^6.7.1",
     "opn": "^4.0.2",
     "ora": "^0.3.0",
     "pify": "^2.3.0",
     "recast": "^0.11.10",
+    "registry-url": "^3.1.0",
+    "tunnel": "0.0.5",
     "update-notifier": "^1.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Updates/closes issue #48 

- Adds support for authenticated proxies through `tunnel` as http proxy agent for `got`.
- Adds `~/.hpmproxy` file to source proxy settings with configurable proxy use killswitch
- Remove dependency on `npm-name` by getting npm name ourselves
- Update readme to reflect proxy changes

Its not the cleanest javascript in the world, my last real node project was back in node 4x and I haven't kept up to date with the syntax changes and such. if anyone wants to clean up the code I won't take it personally.