### PR TITLE
Search for the module exports definition in the AST

### DIFF
--- a/api.js
+++ b/api.js
@@ -27,7 +27,15 @@ try {
 
   parsedFile = recast.parse(fileContents)
 
-  const expression = parsedFile.program.body[0].expression
+  const bodyChunks = parsedFile.program.body
+  const moduleExports = bodyChunks.find(({ expression }) => {
+    if (!expression)
+      return false
+    const objectName   = expression.left.object.name
+    const propertyName = expression.left.property && expression.left.property.name
+    return objectName === 'module' && (propertyName === 'exports')
+  })
+  const expression = moduleExports.expression
   const properties = (expression && expression.right && expression.right.properties) || []
   plugins = properties.find(property => {
     return property.key.name === 'plugins'


### PR DESCRIPTION
Resolve the module.exports definition in the AST by an expression's properties raher than always using the first top level expression declared in the user's .hyper.js config file. Fixes issue #82